### PR TITLE
Compatibility with PeerTube V7

### DIFF
--- a/client/common-client-plugin.js
+++ b/client/common-client-plugin.js
@@ -8,7 +8,7 @@ function register ({ registerHook, peertubeHelpers }) {
         const style = document.createElement('style')
         document.head.appendChild(style)
         const sheet = style.sheet
-        let rule = "#custom-css .icon.icon-logo { "
+        let rule = "#custom-css .icon-logo { "
         rule+= " display: inline-block; "
         rule+= " background: url('"+s['icon_url']+"'); "
         rule+= " background-size: cover;"


### PR DESCRIPTION
This element doesn't have the `.icon` class anymore. We can still rely on `.icon-logo`

See https://github.com/Chocobozzz/PeerTube/releases/tag/v7.0.0-rc.1